### PR TITLE
Expand compatibility to include Puppet 5 and Ubuntu

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,7 +9,7 @@ class ss_monit_apache (
 		ensure => present,
 		owner => root,
 		group => root,
-		mode => 0644,
+		mode => '0644',
 		content => template("ss_monit_apache/apache.erb"),
 		notify  => Service['monit'],
 		require  => File['/etc/monit/conf.d/'],

--- a/metadata.json
+++ b/metadata.json
@@ -10,14 +10,21 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 3.0.0 < 5.0.0"
+      "version_requirement": ">= 3.0.0 < 6.0.0"
     }
   ],
   "operatingsystem_support": [
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "8"
+        "8",
+        "9"
+      ]
+    },
+    {
+      "operatingsystem": "Ubuntu",
+      "operatingsystemrelease": [
+        "18.04"
       ]
     }
   ]


### PR DESCRIPTION
Left-over changes from previous upgrade that were never merged back into a release. currently used by `aws-projects`.